### PR TITLE
Typo fix in layermodifier5dsc description

### DIFF
--- a/EN.json
+++ b/EN.json
@@ -1068,7 +1068,7 @@
         "layermodifier2dsc": "The air here is much warmer than expected!",
         "layermodifier3dsc": "The air here is colder than expected.",
         "layermodifier4dsc": "The air here is totally frigid!",
-        "layermodifier5dsc": "The terrain here is unusally flooded.",
+        "layermodifier5dsc": "The terrain here is unusually flooded.",
         "layermodifier6dsc": "You probably won't find any exposed pools here.",
         "layermodifier7dsc": "Water is dripping from everywhere in here...",
         "layermodifier8dsc": "This place seems to have very high insect activity.",


### PR DESCRIPTION
Typo found in the word "unusually", originally was "unusally".

(delete unrelevant sections)

## Type of Contribution

- [ ] New locale
- [ ] Update to existing locale
- [ ] Fix (typos, grammar, consistency)
- [ ] Other (please describe):

## Target Locale

Language: (e.g. `pt-BR`):
EN.json

## Description

Please describe what this pull request includes:

- Indicate percentage completed.
- If update: explain what was updated (new keys, revision, quality improvements, etc.). 
- Any additional context reviewers should know.

Update revision of a typo in layer description.

## Locale Checklist

### General Requirements

- [x] I’ve read and followed the contribution guide's recommendations.
- [x] No keys are missing or extra compared to `en.json`.
- [x] Untranslated lines remain in **English**.
- [ ] I updated the `README.md`

### Review & Quality

- [ ] The translation has been reviewed by at least one other native speaker.
